### PR TITLE
add pkgconfig compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,18 @@ if(BUILD_TESTS)
   add_executable(tram-tests ${TEST_SOURCES})
   target_link_libraries(tram-tests gtest gtest_main pthread tram)
 endif()
+
+# pkg-config installation
+set(PKGCONFIG_DIR "/usr/lib/pkgconfig")
+# get latest git commit in the working directory
+execute_process(
+    COMMAND git log -1 --format=%h
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+install(TARGETS tram DESTINATION /usr/lib)
+file(GLOB HEADERS . "*.hpp")
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/tram/)
+configure_file(tram.pc.in tram.pc @ONLY)
+install(FILES tram.pc DESTINATION ${PKGCONFIG_DIR})

--- a/README.md
+++ b/README.md
@@ -42,9 +42,25 @@ tram uses familiar stream-like interface for sockets.
 ```
 
 # Using tram in your projects
+Tram can install to `/usr/include` and `/usr/lib` directories. It also installs a `.pc` file to be usable with [pkgconfig](https://people.freedesktop.org/~dbn/pkg-config-guide.html#using) tool. It is, however, **not** required to use pkgconfig to link against tram.
+```
+$ git clone https://github.com/jas-bar/tram
+$ cd tram
+$ cmake .
+$ make
+$ sudo make install
+```
 
-At the moment, you have to setup includes and linking yourself.
-We are working on a better way to use tram via pkgconfig.
+Tram should now be available to you via pkgconfig.
+If you are using CMake to build your project, you add this snippet to your `CMakeLists.txt`:
+```
+include(FindPkgConfig)
+pkg_search_module(TRAM REQUIRED tram)
+```
+After this, `${TRAM_LIBRARIES}` and `${TRAM_INCLUDE_DIRS}` variables are defined, which can be utilized with `target_link_libraries` and `include_directories` respectively.
+If everything is setup right, use `#include <tram/tram.hpp>` in your sources and you're ready to start coding.
+
+For more information about this process, see pull request #12.
 
 # Licensing
 

--- a/tram.pc.in
+++ b/tram.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@/
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: tram
+Description: Tram C++ networking library
+Version: git-@GIT_COMMIT_HASH@
+Cflags: -I${includedir}
+Libs: -L${libdir} -ltram


### PR DESCRIPTION
on `make install` tram installs its static library to `/usr/lib/libtram.a`
and include headers into `/usr/include/tram/tram.hpp`
Pkgconfig provides `/usr/include/` as the only include directory.
tram needs to be included into a project like this:
`# include <tram/tram.hpp>`

to add tram to your CMake project on Linux, use this:

```
include(FindPkgConfig)
pkg_search_module(TRAM REQUIRED tram)
```

the snippet sets up a few CMake variables
(https://cmake.org/cmake/help/v3.0/module/FindPkgConfig.html)
most notably `${TRAM_LIBRARIES}` and `${TRAM_INCLUDE_DIRS}`

Signed-off-by: Tomas Jasek <tomsik68@gmail.com>